### PR TITLE
fix a bug in data_io: data race in scheduler::acquire

### DIFF
--- a/xdl/xdl/data_io/scheduler.cc
+++ b/xdl/xdl/data_io/scheduler.cc
@@ -110,6 +110,7 @@ bool Scheduler::Schedule() {
 }
 
 ReadParam *Scheduler::Acquire() {
+  std::unique_lock<std::mutex> lck(mutex_);
   if (finished_) {
     return nullptr;
   }
@@ -121,7 +122,6 @@ ReadParam *Scheduler::Acquire() {
   if (rparam->ant_ == nullptr) {
     rparam->ant_ = fs_->GetAnt(rparam->path_);
   }
-  std::unique_lock<std::mutex> lck(mutex_);
   using_.insert(rparam);
   XDL_LOG(DEBUG) << "acquire " << rparam->DebugString();
   return rparam;


### PR DESCRIPTION
修复Scheduler::Acquire在线程数多于文件数时触发的一个数据竞争bug